### PR TITLE
Use GitHub actions for testing and linting

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
         id: go
 
       - name: Set up environment
-        runs: |
+        run: |
           # https://github.com/actions/setup-go/issues/14
           echo "::set-env name=GOPATH::$(go env GOPATH)"
           echo "::add-path::$(go env GOPATH)/bin"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,9 @@
 name: Go
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
+
 jobs:
   verify:
     name: Verify
@@ -27,5 +31,5 @@ jobs:
         run: golangci-lint run
 
       - name: Test
-        run: go test -v
+        run: go test -v ./...
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,25 @@
+name: Go
+on: [push]
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
+
+      - name: Lint
+        run: golangci-lint run
+
+      - name: Test
+        run: go test -v
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,5 @@
 name: Go
-on: [push]
+on: [push, pull_request]
 jobs:
   verify:
     name: Verify
@@ -11,11 +11,17 @@ jobs:
           go-version: 1.13
         id: go
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+      - name: Set up environment
+        runs: |
+          # https://github.com/actions/setup-go/issues/14
+          echo "::set-env name=GOPATH::$(go env GOPATH)"
+          echo "::add-path::$(go env GOPATH)/bin"
 
       - name: Install golangci-lint
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
 
       - name: Lint
         run: golangci-lint run

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+run:
+  tests: false
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - gofmt
+    - goimports
+    - golint
+    - govet
+    - ineffassign
+    - typecheck
+    - unconvert
+    - varcheck
+
+issues:
+  exclude-use-default: false
+
+linter-settings:
+  goimports:
+    local-prefixes: github.com/bluekeyes/go-gitdiff


### PR DESCRIPTION
Use `golangci-lint` to coordinate linting instead of installing tools individually. The workflow installs the binary directly instead of using one of the existing public actions.