### PR TITLE
Working/relax email requirements

### DIFF
--- a/gitdiff/patch_header.go
+++ b/gitdiff/patch_header.go
@@ -386,7 +386,7 @@ func parseHeaderMail(mailLine string, r io.Reader) (*PatchHeader, error) {
 	if len(addrs) > 0 {
 		addr := addrs[0]
 		if addr.Name == "" {
-			return nil, fmt.Errorf("invalid user string: %s", addr)
+			addr.Name = addr.Address
 		}
 		h.Author = &PatchIdentity{Name: addr.Name, Email: addr.Address}
 	}

--- a/gitdiff/patch_header_test.go
+++ b/gitdiff/patch_header_test.go
@@ -289,6 +289,21 @@ CC: Joe Smith <joe.smith@company.com>
 				BodyAppendix: expectedBodyAppendix,
 			},
 		},
+		"mailboxMinimal": {
+			Input: `From: Morton Haypenny <mhaypenny@example.com>
+Subject: [PATCH] A sample commit to test header parsing
+
+The medium format shows the body, which
+may wrap on to multiple lines.
+
+Another body line.
+`,
+			Header: PatchHeader{
+				Author: expectedIdentity,
+				Title:  expectedTitle,
+				Body:   expectedBody,
+			},
+		},
 		"unwrapTitle": {
 			Input: `commit 61f5cd90bed4d204ee3feb3aa41ee91d4734855b
 Author: Morton Haypenny <mhaypenny@example.com>

--- a/gitdiff/patch_header_test.go
+++ b/gitdiff/patch_header_test.go
@@ -289,6 +289,21 @@ CC: Joe Smith <joe.smith@company.com>
 				BodyAppendix: expectedBodyAppendix,
 			},
 		},
+		"mailboxMinimalNoName": {
+			Input: `From: <mhaypenny@example.com>
+Subject: [PATCH] A sample commit to test header parsing
+
+The medium format shows the body, which
+may wrap on to multiple lines.
+
+Another body line.
+`,
+			Header: PatchHeader{
+				Author: &PatchIdentity{expectedIdentity.Email, expectedIdentity.Email},
+				Title:  expectedTitle,
+				Body:   expectedBody,
+			},
+		},
 		"mailboxMinimal": {
 			Input: `From: Morton Haypenny <mhaypenny@example.com>
 Subject: [PATCH] A sample commit to test header parsing


### PR DESCRIPTION
OK, last PR for a while.  `git am` is actually somewhat relaxed in what it accepts as far as email-looking things.   There are two things I've encountered so far which go-gitdiff chokes on that git am accepts:

1. `git am` will accept a file which starts with the `From:` line

2. `git am` will accept email-only "From" lines of the form `From: <foo@company.com>`.

With these changes, everything works for my use case.