### PR TITLE
Add emoji support in email subjects

### DIFF
--- a/gitdiff/patch_header.go
+++ b/gitdiff/patch_header.go
@@ -458,13 +458,13 @@ func parseSubject(s string) (string, string) {
 		break
 	}
 
-	return s[:at], decodeUTF8Subject(s[at:])
+	return s[:at], decodeSubject(s[at:])
 }
 
-// Decodes a subject line if encoded using quoted-printable UTF-8 Q encoding. This format is the
-// result of a `git format-patch` when the commit title has an emoji (or other non-ASCII character).
+// Decodes a subject line. Currently only supports quoted-printable UTF-8. This format is the result
+// of a `git format-patch` when the commit title has a non-ASCII character (i.e. an emoji).
 // See for reference: https://stackoverflow.com/questions/27695749/gmail-api-not-respecting-utf-encoding-in-subject
-func decodeUTF8Subject(encoded string) string {
+func decodeSubject(encoded string) string {
 	if !strings.HasPrefix(encoded, "=?UTF-8?q?") {
 		// not UTF-8 encoded
 		return encoded

--- a/gitdiff/patch_header_test.go
+++ b/gitdiff/patch_header_test.go
@@ -139,7 +139,7 @@ func TestParsePatchHeader(t *testing.T) {
 	expectedDate := time.Date(2020, 04, 11, 15, 21, 23, 0, time.FixedZone("PDT", -7*60*60))
 	expectedTitle := "A sample commit to test header parsing"
 	expectedEmojiOneLineTitle := "🤖 Enabling auto-merging"
-	expectedEmojiMultiLineTitle := "🤖 Enabling auto-merging of certain PRs"
+	expectedEmojiMultiLineTitle := "[IA64] Put ia64 config files on the Uwe Kleine-König diet"
 	expectedBody := "The medium format shows the body, which\nmay wrap on to multiple lines.\n\nAnother body line."
 	expectedBodyAppendix := "CC: Joe Smith <joe.smith@company.com>"
 
@@ -292,8 +292,8 @@ Another body line.
 			Input: `From 61f5cd90bed4d204ee3feb3aa41ee91d4734855b Mon Sep 17 00:00:00 2001
 From: Morton Haypenny <mhaypenny@example.com>
 Date: Sat, 11 Apr 2020 15:21:23 -0700
-Subject: [PATCH] =?UTF-8?q?=F0=9F=A4=96=20Enabling=20auto-merging=20of=20c?=
- =?UTF-8?q?ertain=20PRs?=
+Subject: [PATCH] =?UTF-8?q?[IA64]=20Put=20ia64=20config=20files=20on=20the=20?=
+ =?UTF-8?q?Uwe=20Kleine-K=C3=B6nig=20diet?=
 
 The medium format shows the body, which
 may wrap on to multiple lines.

--- a/gitdiff/patch_header_test.go
+++ b/gitdiff/patch_header_test.go
@@ -139,6 +139,7 @@ func TestParsePatchHeader(t *testing.T) {
 	expectedDate := time.Date(2020, 04, 11, 15, 21, 23, 0, time.FixedZone("PDT", -7*60*60))
 	expectedTitle := "A sample commit to test header parsing"
 	expectedEmojiOneLineTitle := "🤖 Enabling auto-merging"
+	expectedEmojiMultiLineTitle := "🤖 Enabling auto-merging of certain PRs"
 	expectedBody := "The medium format shows the body, which\nmay wrap on to multiple lines.\n\nAnother body line."
 	expectedBodyAppendix := "CC: Joe Smith <joe.smith@company.com>"
 
@@ -284,6 +285,26 @@ Another body line.
 				Author:     expectedIdentity,
 				AuthorDate: expectedDate,
 				Title:      expectedEmojiOneLineTitle,
+				Body:       expectedBody,
+			},
+		},
+		"mailboxEmojiMultiLine": {
+			Input: `From 61f5cd90bed4d204ee3feb3aa41ee91d4734855b Mon Sep 17 00:00:00 2001
+From: Morton Haypenny <mhaypenny@example.com>
+Date: Sat, 11 Apr 2020 15:21:23 -0700
+Subject: [PATCH] =?UTF-8?q?=F0=9F=A4=96=20Enabling=20auto-merging=20of=20c?=
+ =?UTF-8?q?ertain=20PRs?=
+
+The medium format shows the body, which
+may wrap on to multiple lines.
+
+Another body line.
+`,
+			Header: PatchHeader{
+				SHA:        expectedSHA,
+				Author:     expectedIdentity,
+				AuthorDate: expectedDate,
+				Title:      expectedEmojiMultiLineTitle,
 				Body:       expectedBody,
 			},
 		},

--- a/gitdiff/patch_header_test.go
+++ b/gitdiff/patch_header_test.go
@@ -138,6 +138,7 @@ func TestParsePatchHeader(t *testing.T) {
 	}
 	expectedDate := time.Date(2020, 04, 11, 15, 21, 23, 0, time.FixedZone("PDT", -7*60*60))
 	expectedTitle := "A sample commit to test header parsing"
+	expectedEmojiOneLineTitle := "🤖 Enabling auto-merging"
 	expectedBody := "The medium format shows the body, which\nmay wrap on to multiple lines.\n\nAnother body line."
 	expectedBodyAppendix := "CC: Joe Smith <joe.smith@company.com>"
 
@@ -264,6 +265,25 @@ Another body line.
 				Author:     expectedIdentity,
 				AuthorDate: expectedDate,
 				Title:      expectedTitle,
+				Body:       expectedBody,
+			},
+		},
+		"mailboxEmojiOneLine": {
+			Input: `From 61f5cd90bed4d204ee3feb3aa41ee91d4734855b Mon Sep 17 00:00:00 2001
+From: Morton Haypenny <mhaypenny@example.com>
+Date: Sat, 11 Apr 2020 15:21:23 -0700
+Subject: [PATCH] =?UTF-8?q?=F0=9F=A4=96=20Enabling=20auto-merging?=
+
+The medium format shows the body, which
+may wrap on to multiple lines.
+
+Another body line.
+`,
+			Header: PatchHeader{
+				SHA:        expectedSHA,
+				Author:     expectedIdentity,
+				AuthorDate: expectedDate,
+				Title:      expectedEmojiOneLineTitle,
 				Body:       expectedBody,
 			},
 		},


### PR DESCRIPTION
When using `git format-patch` to produce email patches, the subject line will be encoded if any extended characters are present (i.e. emoji). This PR decodes those values for the subject, producing the original subject, including any emoji/other-characters.