### PR TITLE
Fix EOF error for some files without final newline

### DIFF
--- a/gitdiff/apply.go
+++ b/gitdiff/apply.go
@@ -231,10 +231,7 @@ func (a *Applier) ApplyTextFragment(dst io.Writer, f *TextFragment) error {
 
 	preimage := make([][]byte, fragEnd-start)
 	n, err := a.lineSrc.ReadLinesAt(preimage, start)
-	switch {
-	case err == nil:
-	case err == io.EOF && n == len(preimage): // last line of frag has no newline character
-	default:
+	if err != nil {
 		return applyError(err, lineNum(start+int64(n)))
 	}
 

--- a/gitdiff/io_test.go
+++ b/gitdiff/io_test.go
@@ -120,18 +120,18 @@ func TestLineReaderAt(t *testing.T) {
 		})
 	}
 
-	incompleteTests := map[string]struct {
+	newlineTests := map[string]struct {
 		InputSize int
 	}{
-		"readLinesIncomplete": {
+		"readLinesNoFinalNewline": {
 			InputSize: indexBufferSize + indexBufferSize/2,
 		},
-		"readLinesIncompleteBufferMultiple": {
-			InputSize: indexBufferSize,
+		"readLinesNoFinalNewlineBufferMultiple": {
+			InputSize: 4 * indexBufferSize,
 		},
 	}
 
-	for name, test := range incompleteTests {
+	for name, test := range newlineTests {
 		t.Run(name, func(t *testing.T) {
 			input := bytes.Repeat([]byte("0"), test.InputSize)
 

--- a/gitdiff/io_test.go
+++ b/gitdiff/io_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestLineReaderAt(t *testing.T) {
+	const lineTemplate = "generated test line %d\n"
+
 	tests := map[string]struct {
 		InputLines int
 		Offset     int64
@@ -42,6 +44,11 @@ func TestLineReaderAt(t *testing.T) {
 			Offset:     2,
 			Count:      0,
 		},
+		"readAllLines": {
+			InputLines: 64,
+			Offset:     0,
+			Count:      64,
+		},
 		"readThroughEOF": {
 			InputLines: 16,
 			Offset:     12,
@@ -70,8 +77,6 @@ func TestLineReaderAt(t *testing.T) {
 			Err:        true,
 		},
 	}
-
-	const lineTemplate = "generated test line %d\n"
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -110,6 +115,53 @@ func TestLineReaderAt(t *testing.T) {
 			for i := 0; i < n; i++ {
 				if !bytes.Equal(output[i], lines[i]) {
 					t.Errorf("incorrect content in line %d:\nexpected: %q\nactual: %q", i, output[i], lines[i])
+				}
+			}
+		})
+	}
+
+	incompleteTests := map[string]struct {
+		InputSize int
+	}{
+		"readLinesIncomplete": {
+			InputSize: indexBufferSize + indexBufferSize/2,
+		},
+		"readLinesIncompleteBufferMultiple": {
+			InputSize: indexBufferSize,
+		},
+	}
+
+	for name, test := range incompleteTests {
+		t.Run(name, func(t *testing.T) {
+			input := bytes.Repeat([]byte("0"), test.InputSize)
+
+			var output [][]byte
+			for i := 0; i < len(input); i++ {
+				last := i
+				i += rand.Intn(80)
+				if i < len(input)-1 { // last character of input must not be a newline
+					input[i] = '\n'
+					output = append(output, input[last:i+1])
+				} else {
+					output = append(output, input[last:])
+				}
+			}
+
+			r := &lineReaderAt{r: bytes.NewReader(input)}
+			lines := make([][]byte, len(output))
+
+			n, err := r.ReadLinesAt(lines, 0)
+			if err != nil {
+				t.Fatalf("unexpected error reading reading lines: %v", err)
+			}
+
+			if n != len(output) {
+				t.Fatalf("incorrect number of lines read: expected %d, actual %d", len(output), n)
+			}
+
+			for i, line := range lines {
+				if !bytes.Equal(output[i], line) {
+					t.Errorf("incorrect content in line %d:\nexpected: %q\nactual: %q", i, output[i], line)
 				}
 			}
 		})


### PR DESCRIPTION
If a file was an exact multiple of 1024 bytes (the size of an internal
buffer) and was missing a final newline, the LineReaderAt implementation
would drop the last line, leading to an unexpected EOF error on apply.

In addition to fixing the bug, slightly change the behavior of
ReadLineAt to reflect how it is actually used:

  1. Clarify that the return value n includes all lines instead of only
     lines with a final newline. This was already true except in the
     case of the bug fixed by this commit.

  2. Only return io.EOF if fewer lines are read than requested. The
     previous implementation also returned io.EOF if the last line was
     missing a final newline, but this was confusing and didn't really
     serve a purpose.

This is technically a breaking change for external implementations but
an implementation that exactly followed the "spec" was already broken in
certain edge cases.