### PR TITLE
Return errors for empty text fragments

### DIFF
--- a/gitdiff/text_test.go
+++ b/gitdiff/text_test.go
@@ -317,6 +317,24 @@ func TestParseTextChunk(t *testing.T) {
 			},
 			Err: true,
 		},
+		"onlyContext": {
+			Input: ` context line
+ context line
+`,
+			Fragment: TextFragment{
+				OldLines: 2,
+				NewLines: 2,
+			},
+			Err: true,
+		},
+		"unexpectedNoNewlineMarker": {
+			Input: `\ No newline at end of file`,
+			Fragment: TextFragment{
+				OldLines: 1,
+				NewLines: 1,
+			},
+			Err: true,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
This fixes two issues:

1. Fragments with only context lines were accepted
2. Fragments with only a "no newline" marker caused a panic

The panic was found by go-fuzz. While fixing that issue, I
discovered the first problem with other types of empty fragments while
comparing behavior against 'git apply'.

Also extract some helper functions and modify the loop conditions to
clean things up while making changes in this area.