### PR TITLE
Fix parsing of mode lines with trailing space

### DIFF
--- a/gitdiff/file_header.go
+++ b/gitdiff/file_header.go
@@ -324,12 +324,12 @@ func parseGitHeaderNewName(f *File, line, defaultName string) error {
 }
 
 func parseGitHeaderOldMode(f *File, line, defaultName string) (err error) {
-	f.OldMode, err = parseMode(line)
+	f.OldMode, err = parseMode(strings.TrimSpace(line))
 	return
 }
 
 func parseGitHeaderNewMode(f *File, line, defaultName string) (err error) {
-	f.NewMode, err = parseMode(line)
+	f.NewMode, err = parseMode(strings.TrimSpace(line))
 	return
 }
 

--- a/gitdiff/file_header_test.go
+++ b/gitdiff/file_header_test.go
@@ -486,12 +486,24 @@ func TestParseGitHeaderData(t *testing.T) {
 				OldMode: os.FileMode(0100644),
 			},
 		},
+		"oldModeWithTrailingSpace": {
+			Line: "old mode 100644\r\n",
+			OutputFile: &File{
+				OldMode: os.FileMode(0100644),
+			},
+		},
 		"invalidOldMode": {
 			Line: "old mode rw\n",
 			Err:  true,
 		},
 		"newMode": {
 			Line: "new mode 100755\n",
+			OutputFile: &File{
+				NewMode: os.FileMode(0100755),
+			},
+		},
+		"newModeWithTrailingSpace": {
+			Line: "new mode 100755\r\n",
 			OutputFile: &File{
 				NewMode: os.FileMode(0100755),
 			},
@@ -511,6 +523,15 @@ func TestParseGitHeaderData(t *testing.T) {
 		},
 		"newFileMode": {
 			Line:        "new file mode 100755\n",
+			DefaultName: "dir/file.txt",
+			OutputFile: &File{
+				NewName: "dir/file.txt",
+				NewMode: os.FileMode(0100755),
+				IsNew:   true,
+			},
+		},
+		"newFileModeWithTrailingSpace": {
+			Line:        "new file mode 100755\r\n",
 			DefaultName: "dir/file.txt",
 			OutputFile: &File{
 				NewName: "dir/file.txt",


### PR DESCRIPTION
If a patch is passed through a system that converts line endings to '\r\n', mode lines end up with trailing whitespace that confuses `strconv.ParseInt`. In Git, this is avoided by using `strtoul()` for parsing, which stops at the first non-digit character.

Changing line endings in patch content itself can cause other problems so it is best to avoid this transform, but if it does happen, it shouldn't cause a parse error.

Fixes #37. I might want to revisit this in the future in favor of something more like `strtoul()`, but for now, I think it is still better to fail on obviously wrong numbers than to silently parse some part of them.