### PR TITLE
Return preamble when a patch has no files

### DIFF
--- a/gitdiff/file_header.go
+++ b/gitdiff/file_header.go
@@ -57,7 +57,7 @@ func (p *parser) ParseNextFileHeader() (*File, string, error) {
 			return nil, "", err
 		}
 	}
-	return nil, "", nil
+	return nil, preamble.String(), nil
 }
 
 func (p *parser) ParseGitFileHeader() (*File, error) {

--- a/gitdiff/parser.go
+++ b/gitdiff/parser.go
@@ -33,6 +33,9 @@ func Parse(r io.Reader) ([]*File, string, error) {
 		if err != nil {
 			return files, preamble, err
 		}
+		if len(files) == 0 {
+			preamble = pre
+		}
 		if file == nil {
 			break
 		}
@@ -50,9 +53,6 @@ func Parse(r io.Reader) ([]*File, string, error) {
 			}
 		}
 
-		if len(files) == 0 {
-			preamble = pre
-		}
 		files = append(files, file)
 	}
 

--- a/gitdiff/parser_test.go
+++ b/gitdiff/parser_test.go
@@ -281,8 +281,13 @@ this is another line
 --- could this be a header?
 nope, it's just some dashes
 `,
-			Output:   nil,
-			Preamble: "",
+			Output: nil,
+			Preamble: `
+this is a line
+this is another line
+--- could this be a header?
+nope, it's just some dashes
+`,
 		},
 		"detatchedFragmentLike": {
 			Input: `
@@ -290,6 +295,10 @@ a wild fragment appears?
 @@ -1,3 +1,4 ~1,5 @@
 `,
 			Output: nil,
+			Preamble: `
+a wild fragment appears?
+@@ -1,3 +1,4 ~1,5 @@
+`,
 		},
 		"detatchedFragment": {
 			Input: `
@@ -425,6 +434,11 @@ Date:   Tue Apr 2 22:55:40 2019 -0700
 				},
 			},
 			Preamble: textPreamble,
+		},
+		"noFiles": {
+			InputFile: "testdata/no_files.patch",
+			Output:    nil,
+			Preamble:  textPreamble,
 		},
 		"newBinaryFile": {
 			InputFile: "testdata/new_binary_file.patch",

--- a/gitdiff/testdata/no_files.patch
+++ b/gitdiff/testdata/no_files.patch
@@ -1,0 +1,8 @@
+commit 5d9790fec7d95aa223f3d20936340bf55ff3dcbe
+Author: Morton Haypenny <mhaypenny@example.com>
+Date:   Tue Apr 2 22:55:40 2019 -0700
+
+    A file with multiple fragments.
+
+    The content is arbitrary.
+


### PR DESCRIPTION
While empty patches with only a header were parsable, the parser discarded the preamble content. This meant callers had to handle this case specially. Now, if we reach the end of the input without finding a file, `Parse()` returns the full content of the patch as the preamble.

Fixes #45.