### PR TITLE
Update Go and golangci-lint versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,18 +9,18 @@ jobs:
     name: Verify
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
-        uses: actions/setup-go@v3
+      - name: Set up Go 1.21
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.21
           
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.49
+          version: v1.59
 
       - name: Test
         run: go test -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,21 +4,41 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gofmt
     - goimports
-    - golint
     - govet
     - ineffassign
     - misspell
+    - revive
     - typecheck
     - unconvert
-    - varcheck
+    - unused
 
 issues:
   exclude-use-default: false
 
-linter-settings:
+linters-settings:
   goimports:
     local-prefixes: github.com/bluekeyes/go-gitdiff
+  revive:
+    rules:
+      # enable all rules from golint
+      - name: context-keys-type
+      - name: time-naming
+      - name: var-declaration
+      - name: unexported-return
+      - name: errorf
+      - name: blank-imports
+      - name: context-as-argument
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: increment-decrement
+      - name: var-naming
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: indent-error-flow

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/bluekeyes/go-gitdiff
 
-go 1.13
+go 1.21


### PR DESCRIPTION
The minimum Go version for the package is now Go 1.21. This is because a future change will use the `slices` package in test code. Note that non-test code in the package should still be compatible with older versions of Go.

As part of this, also update the `golangci-lint` version to one that works with Go 1.21, which required replacing some deprecated linters.