### PR TITLE
[20240820] Add support for tabs along with space

### DIFF
--- a/gitdiff/text.go
+++ b/gitdiff/text.go
@@ -88,7 +88,7 @@ func (p *parser) ParseTextChunk(frag *TextFragment) error {
 		case '\n':
 			data = "\n"
 			fallthrough // newer GNU diff versions create empty context lines
-		case ' ':
+		case ' ', '\t':
 			oldLines--
 			newLines--
 			if frag.LinesAdded == 0 && frag.LinesDeleted == 0 {

--- a/gitdiff/text_test.go
+++ b/gitdiff/text_test.go
@@ -246,6 +246,26 @@ func TestParseTextChunk(t *testing.T) {
 				LinesAdded: 3,
 			},
 		},
+		"addTabSpace": {
+			Input: `+new line 1
++	new line 2
++    new line 3
+`,
+			Fragment: TextFragment{
+				OldLines: 0,
+				NewLines: 3,
+			},
+			Output: &TextFragment{
+				OldLines: 0,
+				NewLines: 3,
+				Lines: []Line{
+					{OpAdd, "new line 1\n"},
+					{OpAdd, "	new line 2\n"},
+					{OpAdd, "    new line 3\n"},
+				},
+				LinesAdded: 3,
+			},
+		},
 		"deleteAll": {
 			Input: `-old line 1
 -old line 2


### PR DESCRIPTION
When a line starts with a tabulation the patch parsing fails.
`gitdiff: line 15: invalid line operation: '\t'`

Updated the switch to support it.
Added a test to verify it works.