### PR TITLE
bugfix: binary files detect case missing.

### DIFF
--- a/gitdiff/binary.go
+++ b/gitdiff/binary.go
@@ -56,7 +56,11 @@ func (p *parser) ParseBinaryMarker() (isBinary bool, hasData bool, err error) {
 	case "Binary files differ\n":
 	case "Files differ\n":
 	default:
-		return false, false, nil
+		if strings.HasPrefix(p.Line(0), "Binary files") && strings.HasSuffix(p.Line(0), "differ\n") {
+			// for some git version, it comes as "Binary files {filepath} differ\n"
+		} else {
+			return false, false, nil
+		}
 	}
 
 	if err = p.Next(); err != nil && err != io.EOF {

--- a/gitdiff/binary_test.go
+++ b/gitdiff/binary_test.go
@@ -25,6 +25,11 @@ func TestParseBinaryMarker(t *testing.T) {
 			IsBinary: true,
 			HasData:  false,
 		},
+		"binaryFileNoPatch2": {
+			Input:    "Binary files path/to/the/file differ\n",
+			IsBinary: true,
+			HasData:  false,
+		},
 		"textFile": {
 			Input:    "@@ -10,14 +22,31 @@\n",
 			IsBinary: false,


### PR DESCRIPTION
As title, I found some git version output diff patch with binary as below
```
Binary files path/to/the/file` differ\n
```

This is a missing case in go-gitdiff module which only match "Binary files differ\n".