### PR TITLE
Parse binary headers with file paths

### DIFF
--- a/gitdiff/binary.go
+++ b/gitdiff/binary.go
@@ -50,11 +50,11 @@ func (p *parser) ParseBinaryFragments(f *File) (n int, err error) {
 }
 
 func (p *parser) ParseBinaryMarker() (isBinary bool, hasData bool, err error) {
-	switch p.Line(0) {
-	case "GIT binary patch\n":
+	line := p.Line(0)
+	switch {
+	case line == "GIT binary patch\n":
 		hasData = true
-	case "Binary files differ\n":
-	case "Files differ\n":
+	case isBinaryNoDataMarker(line):
 	default:
 		return false, false, nil
 	}
@@ -63,6 +63,13 @@ func (p *parser) ParseBinaryMarker() (isBinary bool, hasData bool, err error) {
 		return false, false, err
 	}
 	return true, hasData, nil
+}
+
+func isBinaryNoDataMarker(line string) bool {
+	if strings.HasSuffix(line, " differ\n") {
+		return strings.HasPrefix(line, "Binary files ") || strings.HasPrefix(line, "Files ")
+	}
+	return false
 }
 
 func (p *parser) ParseBinaryFragmentHeader() (*BinaryFragment, error) {

--- a/gitdiff/binary_test.go
+++ b/gitdiff/binary_test.go
@@ -25,6 +25,16 @@ func TestParseBinaryMarker(t *testing.T) {
 			IsBinary: true,
 			HasData:  false,
 		},
+		"binaryFileNoPatchPaths": {
+			Input:    "Binary files a/foo.bin and b/foo.bin differ\n",
+			IsBinary: true,
+			HasData:  false,
+		},
+		"fileNoPatch": {
+			Input:    "Files differ\n",
+			IsBinary: true,
+			HasData:  false,
+		},
 		"textFile": {
 			Input:    "@@ -10,14 +22,31 @@\n",
 			IsBinary: false,


### PR DESCRIPTION
Some patches may include one or more file paths as part of the binary header when there is no binary data. Git accounts for this by only checking the prefix and suffix of the line, but I missed that logic when implementing this originally.

Alternate to #54.