### PR TITLE
Fix binary headers in formatted patches

### DIFF
--- a/gitdiff/format.go
+++ b/gitdiff/format.go
@@ -169,7 +169,11 @@ func (fm *formatter) FormatFile(f *File) {
 
 	if f.IsBinary {
 		if f.BinaryFragment == nil {
-			fm.WriteString("Binary files fmer\n")
+			fm.WriteString("Binary files ")
+			fm.WriteQuotedName("a/" + aName)
+			fm.WriteString(" and ")
+			fm.WriteQuotedName("b/" + bName)
+			fm.WriteString(" differ\n")
 		} else {
 			fm.WriteString("GIT binary patch\n")
 			fm.FormatBinaryFragment(f.BinaryFragment)

--- a/gitdiff/format_roundtrip_test.go
+++ b/gitdiff/format_roundtrip_test.go
@@ -31,6 +31,7 @@ func TestFormatRoundtrip(t *testing.T) {
 		// data is slightly different when re-encoded by Go.
 		{File: "binary_modify.patch", SkipTextCompare: true},
 		{File: "binary_new.patch", SkipTextCompare: true},
+		{File: "binary_modify_nodata.patch"},
 	}
 
 	for _, patch := range patches {

--- a/gitdiff/testdata/string/binary_modify_nodata.patch
+++ b/gitdiff/testdata/string/binary_modify_nodata.patch
@@ -1,0 +1,3 @@
+diff --git a/file.bin b/file.bin
+index a7f4d5d..bdc9a70 100644
+Binary files a/file.bin and b/file.bin differ


### PR DESCRIPTION
Include file names in the header (now that we can actually parse them) and fix a bad find-and-replace that changed "differ" to "fmer". Add a new test to verify that binary files without data format correctly.