### PR TITLE
Add a test for removing the last newline in a file

### DIFF
--- a/gitdiff/apply_test.go
+++ b/gitdiff/apply_test.go
@@ -22,6 +22,7 @@ func TestApplyTextFragment(t *testing.T) {
 		"changeStart":       {Files: getApplyFiles("text_fragment_change_start")},
 		"changeMiddle":      {Files: getApplyFiles("text_fragment_change_middle")},
 		"changeEnd":         {Files: getApplyFiles("text_fragment_change_end")},
+		"changeEndEOL":      {Files: getApplyFiles("text_fragment_change_end_eol")},
 		"changeExact":       {Files: getApplyFiles("text_fragment_change_exact")},
 		"changeSingleNoEOL": {Files: getApplyFiles("text_fragment_change_single_noeol")},
 

--- a/gitdiff/testdata/apply/text_fragment_change_end_eol.out
+++ b/gitdiff/testdata/apply/text_fragment_change_end_eol.out
@@ -1,0 +1,3 @@
+line 1
+line 2
+line 3

--- a/gitdiff/testdata/apply/text_fragment_change_end_eol.patch
+++ b/gitdiff/testdata/apply/text_fragment_change_end_eol.patch
@@ -1,0 +1,10 @@
+diff --git a/gitdiff/testdata/apply/text_fragment_remove_last_eol.src b/gitdiff/testdata/apply/text_fragment_remove_last_eol.src
+index a92d664..8cf2f17 100644
+--- a/gitdiff/testdata/apply/text_fragment_remove_last_eol.src
++++ b/gitdiff/testdata/apply/text_fragment_remove_last_eol.src
+@@ -1,3 +1,3 @@
+ line 1
+ line 2
+-line 3
++line 3
+\ No newline at end of file

--- a/gitdiff/testdata/apply/text_fragment_change_end_eol.src
+++ b/gitdiff/testdata/apply/text_fragment_change_end_eol.src
@@ -1,0 +1,3 @@
+line 1
+line 2
+line 3


### PR DESCRIPTION
This worked, but completes the test coverage in combination with the test that adds a final newline and one that leaves the missing newline in place.