### PR TITLE
Run 'go fix' to modernize code

### DIFF
--- a/gitdiff/apply.go
+++ b/gitdiff/apply.go
@@ -61,7 +61,7 @@ type fragLineNum int
 
 // applyError creates a new *ApplyError wrapping err or augments the information
 // in err with args if it is already an *ApplyError. Returns nil if err is nil.
-func applyError(err error, args ...interface{}) error {
+func applyError(err error, args ...any) error {
 	if err == nil {
 		return nil
 	}

--- a/gitdiff/apply_test.go
+++ b/gitdiff/apply_test.go
@@ -165,7 +165,7 @@ func TestApplyFile(t *testing.T) {
 
 type applyTest struct {
 	Files applyFiles
-	Err   interface{}
+	Err   any
 }
 
 func (at applyTest) run(t *testing.T, apply func(io.Writer, io.ReaderAt, *File) error) {

--- a/gitdiff/assert_test.go
+++ b/gitdiff/assert_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func assertError(t *testing.T, expected interface{}, actual error, action string) {
+func assertError(t *testing.T, expected any, actual error, action string) {
 	if actual == nil {
 		t.Fatalf("expected error %s, but got nil", action)
 	}

--- a/gitdiff/io_test.go
+++ b/gitdiff/io_test.go
@@ -87,7 +87,7 @@ func TestLineReaderAt(t *testing.T) {
 
 			output := make([][]byte, test.Count)
 			for i := 0; i < test.Count; i++ {
-				output[i] = []byte(fmt.Sprintf(lineTemplate, test.Offset+int64(i)))
+				output[i] = fmt.Appendf(nil, lineTemplate, test.Offset+int64(i))
 			}
 
 			r := &lineReaderAt{r: bytes.NewReader(input.Bytes())}

--- a/gitdiff/parser.go
+++ b/gitdiff/parser.go
@@ -137,6 +137,6 @@ func (p *parser) Line(delta uint) string {
 }
 
 // Errorf generates an error and appends the current line information.
-func (p *parser) Errorf(delta int64, msg string, args ...interface{}) error {
+func (p *parser) Errorf(delta int64, msg string, args ...any) error {
 	return fmt.Errorf("gitdiff: line %d: %s", p.lineno+delta, fmt.Sprintf(msg, args...))
 }

--- a/gitdiff/patch_header.go
+++ b/gitdiff/patch_header.go
@@ -186,9 +186,9 @@ func ParsePatchHeader(header string, options ...PatchHeaderOption) (*PatchHeader
 	}
 
 	var firstLine, rest string
-	if idx := strings.IndexByte(header, '\n'); idx >= 0 {
-		firstLine = header[:idx]
-		rest = header[idx+1:]
+	if before, after, ok := strings.Cut(header, "\n"); ok {
+		firstLine = before
+		rest = after
 	} else {
 		firstLine = header
 		rest = ""
@@ -362,8 +362,8 @@ func parseHeaderMail(mailLine string, r io.Reader, opts patchHeaderOptions) (*Pa
 
 	h := &PatchHeader{}
 
-	if strings.HasPrefix(mailLine, mailHeaderPrefix) {
-		mailLine = strings.TrimPrefix(mailLine, mailHeaderPrefix)
+	if after, ok := strings.CutPrefix(mailLine, mailHeaderPrefix); ok {
+		mailLine = after
 		if i := strings.IndexByte(mailLine, ' '); i > 0 {
 			h.SHA = mailLine[:i]
 		}

--- a/gitdiff/patch_header_test.go
+++ b/gitdiff/patch_header_test.go
@@ -11,7 +11,7 @@ func TestParsePatchDate(t *testing.T) {
 	tests := map[string]struct {
 		Input  string
 		Output time.Time
-		Err    interface{}
+		Err    any
 	}{
 		"default": {
 			Input:  "Thu Apr 9 01:07:06 2020 -0700",
@@ -88,7 +88,7 @@ func TestParsePatchHeader(t *testing.T) {
 		Input   string
 		Options []PatchHeaderOption
 		Header  PatchHeader
-		Err     interface{}
+		Err     any
 	}{
 		"prettyShort": {
 			Input: `commit 61f5cd90bed4d204ee3feb3aa41ee91d4734855b

--- a/gitdiff/patch_identity_test.go
+++ b/gitdiff/patch_identity_test.go
@@ -8,7 +8,7 @@ func TestParsePatchIdentity(t *testing.T) {
 	tests := map[string]struct {
 		Input  string
 		Output PatchIdentity
-		Err    interface{}
+		Err    any
 	}{
 		"simple": {
 			Input: "Morton Haypenny <mhaypenny@example.com>",

--- a/gitdiff/text.go
+++ b/gitdiff/text.go
@@ -183,10 +183,3 @@ func parseRange(s string) (start int64, end int64, err error) {
 
 	return
 }
-
-func max(a, b int64) int64 {
-	if a > b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
This only updates to Go 1.21 baseline, which is what the module still specifies as the minimum version. I'll need to run this again when moving to Go 1.25 or 1.26 as minimum.