### PR TITLE
Fix applying patches with zero-context fragments

### DIFF
--- a/gitdiff/apply.go
+++ b/gitdiff/apply.go
@@ -120,6 +120,19 @@ func Apply(dst io.Writer, src io.ReaderAt, f *File, opts ...ApplyOption) error {
 		return applier.Close()
 
 	case len(f.TextFragments) > 0:
+		// creating a file requires an empty source; a fragment starting at
+		// position 0 is not enough to detect this, as zero-context patches use
+		// the same position to insert before the first line of an existing file
+		if f.IsNew {
+			ok, err := isLen(src, 0)
+			if err != nil {
+				return applyError(err)
+			}
+			if !ok {
+				return applyError(&Conflict{"cannot create new file from non-empty src"})
+			}
+		}
+
 		frags := make([]*TextFragment, len(f.TextFragments))
 		copy(frags, f.TextFragments)
 
@@ -135,6 +148,14 @@ func Apply(dst io.Writer, src io.ReaderAt, f *File, opts ...ApplyOption) error {
 		for i, frag := range frags {
 			if err := applier.ApplyFragment(frag); err != nil {
 				return applyError(err, fragNum(i))
+			}
+		}
+		// deleting a file must consume the whole source; a fragment ending at
+		// new position 0 is not enough to detect this, as zero-context patches
+		// use the same position to delete the first line of a file
+		if f.IsDelete {
+			if err := applier.checkFullDelete(); err != nil {
+				return err
 			}
 		}
 		return applier.Close()

--- a/gitdiff/apply_test.go
+++ b/gitdiff/apply_test.go
@@ -19,6 +19,14 @@ func TestApplyTextFragment(t *testing.T) {
 		"addEnd":      {Files: getApplyFiles("text_fragment_add_end")},
 		"addEndNoEOL": {Files: getApplyFiles("text_fragment_add_end_noeol")},
 
+		// zero-context fragments: the old range is empty and OldPosition is the
+		// line the content follows, not the line it starts at
+		"insertStart":  {Files: getApplyFiles("text_fragment_insert_start")},
+		"insertMiddle": {Files: getApplyFiles("text_fragment_insert_middle")},
+		"insertEnd":    {Files: getApplyFiles("text_fragment_insert_end")},
+		"insertNoEOL":  {Files: getApplyFiles("text_fragment_insert_noeol")},
+		"deleteStart":  {Files: getApplyFiles("text_fragment_delete_start")},
+
 		"changeStart":       {Files: getApplyFiles("text_fragment_change_start")},
 		"changeMiddle":      {Files: getApplyFiles("text_fragment_change_middle")},
 		"changeEnd":         {Files: getApplyFiles("text_fragment_change_end")},
@@ -65,13 +73,6 @@ func TestApplyTextFragment(t *testing.T) {
 			Files: applyFiles{
 				Src:   "text_fragment_error.src",
 				Patch: "text_fragment_error_delete_conflict.patch",
-			},
-			Err: &Conflict{},
-		},
-		"errorNewFile": {
-			Files: applyFiles{
-				Src:   "text_fragment_error.src",
-				Patch: "text_fragment_error_new_file.patch",
 			},
 			Err: &Conflict{},
 		},
@@ -197,6 +198,19 @@ func TestApplyFile(t *testing.T) {
 			Files: applyFiles{
 				Src:   "file_text.src",
 				Patch: "file_text_error_partial_delete.patch",
+			},
+			Err: &Conflict{},
+		},
+		"textInsertZeroContext": {
+			Files: getApplyFiles("file_text_insert_zero_context"),
+		},
+		"textDeleteStartZeroContext": {
+			Files: getApplyFiles("file_text_delete_start"),
+		},
+		"textErrorNewNonEmpty": {
+			Files: applyFiles{
+				Src:   "file_text.src",
+				Patch: "file_text_error_new_non_empty.patch",
 			},
 			Err: &Conflict{},
 		},

--- a/gitdiff/apply_text.go
+++ b/gitdiff/apply_text.go
@@ -64,8 +64,13 @@ func (a *TextApplier) ApplyFragment(f *TextFragment) error {
 		return applyError(err)
 	}
 
-	// lines are 0-indexed, positions are 1-indexed (but new files have position = 0)
+	// lines are 0-indexed, positions are 1-indexed; a fragment with no old
+	// lines inserts after OldPosition instead of starting at it, so position 0
+	// inserts before the first line
 	fragStart := f.OldPosition - 1
+	if f.OldLines == 0 {
+		fragStart = f.OldPosition
+	}
 	if fragStart < 0 {
 		fragStart = 0
 	}
@@ -77,16 +82,6 @@ func (a *TextApplier) ApplyFragment(f *TextFragment) error {
 	start := a.nextLine
 	if fragStart < start {
 		return applyError(&Conflict{"fragment overlaps with an applied fragment"})
-	}
-
-	if f.OldPosition == 0 {
-		ok, err := isLen(a.src, 0)
-		if err != nil {
-			return applyError(err)
-		}
-		if !ok {
-			return applyError(&Conflict{"cannot create new file from non-empty src"})
-		}
 	}
 
 	preimage, err := readPreimage(a.lineSrc, start, fragEnd-start)
@@ -116,18 +111,21 @@ func (a *TextApplier) ApplyFragment(f *TextFragment) error {
 	}
 	a.nextLine = fragStart + used
 
-	// new position of +0,0 mean a full delete, so check for leftovers
-	if f.NewPosition == 0 && f.NewLines == 0 {
-		var b [1][]byte
-		n, err := a.lineSrc.ReadLinesAt(b[:], a.nextLine)
-		if err != nil && err != io.EOF {
-			return applyError(err, lineNum(a.nextLine))
-		}
-		if n > 0 {
-			return applyError(&Conflict{"src still has content after full delete"}, lineNum(a.nextLine))
-		}
-	}
+	return nil
+}
 
+// checkFullDelete returns a *Conflict if the source contains content that was
+// not consumed by the applied fragments. Deleting a file is a property of the
+// file header, so only [Apply] can decide when this check applies.
+func (a *TextApplier) checkFullDelete() error {
+	var b [1][]byte
+	n, err := a.lineSrc.ReadLinesAt(b[:], a.nextLine)
+	if err != nil && err != io.EOF {
+		return applyError(err, lineNum(a.nextLine))
+	}
+	if n > 0 {
+		return applyError(&Conflict{"src still has content after full delete"}, lineNum(a.nextLine))
+	}
 	return nil
 }
 

--- a/gitdiff/testdata/apply/file_text_delete_start.out
+++ b/gitdiff/testdata/apply/file_text_delete_start.out
@@ -1,0 +1,5 @@
+line 2
+line 3
+line 4
+line 5
+line 6

--- a/gitdiff/testdata/apply/file_text_delete_start.patch
+++ b/gitdiff/testdata/apply/file_text_delete_start.patch
@@ -1,0 +1,5 @@
+diff --git a/gitdiff/testdata/apply/file_text_delete_start.src b/gitdiff/testdata/apply/file_text_delete_start.src
+--- a/gitdiff/testdata/apply/file_text_delete_start.src
++++ b/gitdiff/testdata/apply/file_text_delete_start.src
+@@ -1 +0,0 @@
+-line 1

--- a/gitdiff/testdata/apply/file_text_delete_start.src
+++ b/gitdiff/testdata/apply/file_text_delete_start.src
@@ -1,0 +1,6 @@
+line 1
+line 2
+line 3
+line 4
+line 5
+line 6

--- a/gitdiff/testdata/apply/file_text_error_new_non_empty.patch
+++ b/gitdiff/testdata/apply/file_text_error_new_non_empty.patch
@@ -1,0 +1,8 @@
+diff --git a/gitdiff/testdata/apply/file_text.src b/gitdiff/testdata/apply/file_text.src
+new file mode 100644
+--- /dev/null
++++ b/gitdiff/testdata/apply/file_text.src
+@@ -0,0 +1,3 @@
++this is line 1
++this is line 2
++this is line 3

--- a/gitdiff/testdata/apply/file_text_insert_zero_context.out
+++ b/gitdiff/testdata/apply/file_text_insert_zero_context.out
@@ -1,0 +1,8 @@
+new line a
+line 1
+line 2
+line 3
+line 4
+line 5
+line 6
+new line b

--- a/gitdiff/testdata/apply/file_text_insert_zero_context.patch
+++ b/gitdiff/testdata/apply/file_text_insert_zero_context.patch
@@ -1,0 +1,7 @@
+diff --git a/gitdiff/testdata/apply/file_text_insert_zero_context.src b/gitdiff/testdata/apply/file_text_insert_zero_context.src
+--- a/gitdiff/testdata/apply/file_text_insert_zero_context.src
++++ b/gitdiff/testdata/apply/file_text_insert_zero_context.src
+@@ -0,0 +1 @@
++new line a
+@@ -6,0 +8 @@ line 6
++new line b

--- a/gitdiff/testdata/apply/file_text_insert_zero_context.src
+++ b/gitdiff/testdata/apply/file_text_insert_zero_context.src
@@ -1,0 +1,6 @@
+line 1
+line 2
+line 3
+line 4
+line 5
+line 6

--- a/gitdiff/testdata/apply/text_fragment_delete_start.patch
+++ b/gitdiff/testdata/apply/text_fragment_delete_start.patch
@@ -1,0 +1,5 @@
+diff --git a/gitdiff/testdata/apply/fragment_delete_start.src b/gitdiff/testdata/apply/fragment_delete_start.src
+--- a/gitdiff/testdata/apply/fragment_delete_start.src
++++ b/gitdiff/testdata/apply/fragment_delete_start.src
+@@ -1 +0,0 @@
+-line 1

--- a/gitdiff/testdata/apply/text_fragment_delete_start.src
+++ b/gitdiff/testdata/apply/text_fragment_delete_start.src
@@ -1,0 +1,3 @@
+line 1
+line 2
+line 3

--- a/gitdiff/testdata/apply/text_fragment_error_new_file.patch
+++ b/gitdiff/testdata/apply/text_fragment_error_new_file.patch
@@ -1,7 +1,0 @@
-diff --git a/gitdiff/testdata/apply/text_fragment_error.src b/gitdiff/testdata/apply/text_fragment_error.src
---- a/gitdiff/testdata/apply/text_fragment_error.src
-+++ b/gitdiff/testdata/apply/text_fragment_error.src
-@@ -0,0 +1,3 @@
-+line 1
-+line 2
-+line 3

--- a/gitdiff/testdata/apply/text_fragment_insert_end.out
+++ b/gitdiff/testdata/apply/text_fragment_insert_end.out
@@ -1,0 +1,5 @@
+line 1
+line 2
+line 3
+new line a
+new line b

--- a/gitdiff/testdata/apply/text_fragment_insert_end.patch
+++ b/gitdiff/testdata/apply/text_fragment_insert_end.patch
@@ -1,0 +1,6 @@
+diff --git a/gitdiff/testdata/apply/fragment_insert_end.src b/gitdiff/testdata/apply/fragment_insert_end.src
+--- a/gitdiff/testdata/apply/fragment_insert_end.src
++++ b/gitdiff/testdata/apply/fragment_insert_end.src
+@@ -3,0 +4,2 @@ line 3
++new line a
++new line b

--- a/gitdiff/testdata/apply/text_fragment_insert_end.src
+++ b/gitdiff/testdata/apply/text_fragment_insert_end.src
@@ -1,0 +1,3 @@
+line 1
+line 2
+line 3

--- a/gitdiff/testdata/apply/text_fragment_insert_middle.out
+++ b/gitdiff/testdata/apply/text_fragment_insert_middle.out
@@ -1,0 +1,3 @@
+line 1
+line 2
+new line a

--- a/gitdiff/testdata/apply/text_fragment_insert_middle.patch
+++ b/gitdiff/testdata/apply/text_fragment_insert_middle.patch
@@ -1,0 +1,5 @@
+diff --git a/gitdiff/testdata/apply/fragment_insert_middle.src b/gitdiff/testdata/apply/fragment_insert_middle.src
+--- a/gitdiff/testdata/apply/fragment_insert_middle.src
++++ b/gitdiff/testdata/apply/fragment_insert_middle.src
+@@ -2,0 +3 @@ line 2
++new line a

--- a/gitdiff/testdata/apply/text_fragment_insert_middle.src
+++ b/gitdiff/testdata/apply/text_fragment_insert_middle.src
@@ -1,0 +1,3 @@
+line 1
+line 2
+line 3

--- a/gitdiff/testdata/apply/text_fragment_insert_noeol.out
+++ b/gitdiff/testdata/apply/text_fragment_insert_noeol.out
@@ -1,0 +1,2 @@
+line 1
+new line a

--- a/gitdiff/testdata/apply/text_fragment_insert_noeol.patch
+++ b/gitdiff/testdata/apply/text_fragment_insert_noeol.patch
@@ -1,0 +1,5 @@
+diff --git a/gitdiff/testdata/apply/fragment_insert_noeol.src b/gitdiff/testdata/apply/fragment_insert_noeol.src
+--- a/gitdiff/testdata/apply/fragment_insert_noeol.src
++++ b/gitdiff/testdata/apply/fragment_insert_noeol.src
+@@ -1,0 +2 @@ line 1
++new line a

--- a/gitdiff/testdata/apply/text_fragment_insert_noeol.src
+++ b/gitdiff/testdata/apply/text_fragment_insert_noeol.src
@@ -1,0 +1,3 @@
+line 1
+line 2
+line 3

--- a/gitdiff/testdata/apply/text_fragment_insert_start.out
+++ b/gitdiff/testdata/apply/text_fragment_insert_start.out
@@ -1,0 +1,2 @@
+new line a
+new line b

--- a/gitdiff/testdata/apply/text_fragment_insert_start.patch
+++ b/gitdiff/testdata/apply/text_fragment_insert_start.patch
@@ -1,0 +1,6 @@
+diff --git a/gitdiff/testdata/apply/fragment_insert_start.src b/gitdiff/testdata/apply/fragment_insert_start.src
+--- a/gitdiff/testdata/apply/fragment_insert_start.src
++++ b/gitdiff/testdata/apply/fragment_insert_start.src
+@@ -0,0 +1,2 @@
++new line a
++new line b

--- a/gitdiff/testdata/apply/text_fragment_insert_start.src
+++ b/gitdiff/testdata/apply/text_fragment_insert_start.src
@@ -1,0 +1,3 @@
+line 1
+line 2
+line 3


### PR DESCRIPTION
Zero-context (`-U0`) insertions are applied one line too early, and `Apply` returns nil, so the output is silently wrong rather than an error:

```
src: A B C     patch: @@ -3,0 +4 @@
                      +D

go-gitdiff:               A B D C
git apply --unidiff-zero: A B C D
GNU patch:                A B C D
```

A zero-length range in a hunk header is positional — `@@ -3,0 +4 @@` inserts *after* old line 3 — but the applier starts every fragment at `OldPosition - 1`. Two nearby checks read file-level facts off the same ambiguous positions and reject patches that `git apply --unidiff-zero` and GNU `patch` both accept: `@@ -0,0 +1 @@` (insert before line 1) is read as file creation, and `@@ -1 +0,0 @@` (delete line 1) as a full delete. The fix starts a fragment at `OldPosition` when it has no old lines, and moves those two checks into `Apply` behind `File.IsNew`/`File.IsDelete` — the fields `ParseTextFragments` already uses to answer the same questions.

Tested by diffing against `git apply --unidiff-zero` and GNU `patch` over ~9,700 generated patches (`-U0`–`-U3`, insert/delete/replace at file start, middle and end, multi-hunk, empty files, no trailing newline, CRLF, and the `File.String()` round-trip): 162 wrong results at `-U0` before, 0 after, `-U1`–`-U3` unchanged. One existing expectation changes — `text_fragment_error_new_file.patch` is not a new-file patch (no `/dev/null` side, no `new file mode`), and git and GNU patch both apply it as an insertion before line 1, so it is replaced by a file-level test using a real new-file patch that still reports a conflict.
